### PR TITLE
Added support for JSON data extraction.

### DIFF
--- a/GreenSkyMQTTBridge.indigoPlugin/Contents/Info.plist
+++ b/GreenSkyMQTTBridge.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>4.0.0</string>
+	<string>4.1.0</string>
 	<key>ServerApiVersion</key>
 	<string>1.0.0</string>
 	<key>IwsApiVersion</key>

--- a/GreenSkyMQTTBridge.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/GreenSkyMQTTBridge.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -83,6 +83,9 @@
 			<Field id="stateTopic" type="textfield" defaultValue="">
 				<Label>State Topic:</Label>
 			</Field>
+			<Field id="payloadExtraction" type="textfield" defaultValue="">
+				<Label>Payload Extraction:</Label>
+			</Field>
 			<Field id="unit" type="textfield" defaultValue="">
 				<Label>Unit:</Label>
 			</Field>


### PR DESCRIPTION
If payload data from MQTT sensors is in a JSON format, there needs to be a way to extract a value from the JSON. You can now specify a data path in the MQTT Sensor device config.

**Example:**
payload format: `{"AM2301": {"Temperature": 78.8}}`
Extraction field to get the temperature value: `AM2301->Temperature`